### PR TITLE
[Docs] "gas-booster" should be "gas-filter" in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ If you would like to filter results according to a user's friends evaluation, it
     "query" : {
         "match_all" : {}
     },
-    "gas-booster" :{
+    "gas-filter" :{
           "name": "SearchResultCypherFilter",
           "query": "MATCH (input:User) WHERE id(input) = 2
                    MATCH (input)-[f:FRIEND_OF]->(friend)-[r:RATED]->(movie)


### PR DESCRIPTION
I spent a while banging my head against a wall because I copied the `SearchResultCypherFilter` example in `README.md` and it used `gas-booster` as the query-dict key instead of `gas-filter`.

This PR just updates the docs to be correct.