### PR TITLE
Upgrade to ES version 2.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ The following version are currently supported
 
 | Version (this project)   | Elasticsearch |
 |:---------:|:-------------:|
-| master    | 2.4.1         |
+| master    | 2.4.4         |
 | 2.3.2.2   | 2.3.2         |
 | 2.3.1.0   | 2.3.1         |
 | 2.2.2.0   | 2.2.2         |

--- a/pom.xml
+++ b/pom.xml
@@ -21,12 +21,12 @@
 
     <groupId>com.graphaware.es</groupId>
     <artifactId>graph-aided-search</artifactId>
-    <version>2.4.1.4-SNAPSHOT</version>
+    <version>2.4.4.4-SNAPSHOT</version>
 
     <properties>
         <java.version>1.7</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <elasticsearch.version>2.4.1</elasticsearch.version>
+        <elasticsearch.version>2.4.4</elasticsearch.version>
         <bolt.version>1.1.0-M04</bolt.version>
         <elasticsearch.plugin.classname>com.graphaware.es.gas.GraphAidedSearchPlugin</elasticsearch.plugin.classname>
         <maven.compiler.source>1.7</maven.compiler.source>


### PR DESCRIPTION
The latest 2.4.x version of elasticsearch is 2.4.4. There are no breaking changes, only bug fixes, and so we should be safe to upgrade. This is currently an issue as the install errors out when run against ES 2.4.4. I was following the previous 2.4.1 version bump for this commit, the biggest piece I was uncertain about was the plugin version bump.

Here's the error:
```
$ ./bin/plugin install com.graphaware.es/graph-aided-search/2.4.1.3
-> Installing com.graphaware.es/graph-aided-search/2.4.1.3...
Trying https://download.elastic.co/com.graphaware.es/graph-aided-search/graph-aided-search-2.4.1.3.zip ...
Trying https://search.maven.org/remotecontent?filepath=com/graphaware/es/graph-aided-search/2.4.1.3/graph-aided-search-2.4.1.3.zip ...
Downloading ....................................................................................................................................................................................................................................................DONE
Verifying https://search.maven.org/remotecontent?filepath=com/graphaware/es/graph-aided-search/2.4.1.3/graph-aided-search-2.4.1.3.zip checksums if available ...
Downloading .DONE
ERROR: Plugin [graph-aided-search] is incompatible with Elasticsearch [2.4.4]. Was designed for version [2.4.1]
```